### PR TITLE
Add requiresSQLCommentHint

### DIFF
--- a/src/Type/UrlType.php
+++ b/src/Type/UrlType.php
@@ -25,4 +25,12 @@ class UrlType extends StringType
     {
         return self::URL;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function requiresSQLCommentHint(AbstractPlatform $platform)
+    {
+        return true;
+    }
 }


### PR DESCRIPTION
This allow's Doctrine Migrations to detect which type of field it is. Currently when you use this type doctrine keeps telling me that the field is changed because it does not know about the custom type. 

More info on the topic: 
- http://stackoverflow.com/questions/15661139/doctrine-custom-type-always-altering-table
- https://github.com/doctrine/dbal/issues/1614
