### PR TITLE
Fix: Use league/uri instead of league/url

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     },
     "require-dev": {
         "doctrine/orm": "^2.5",
-        "league/url": "^3.3",
+        "league/uri": "^4.1.1",
         "phpunit/phpunit": ">=4.8"
     },
     "license": "MIT",
@@ -18,7 +18,7 @@
         }
     ],
     "suggest": {
-        "league/url": "For use with the UrlType"
+        "league/uri": "For use with the UrlType"
     },
     "autoload": {
         "psr-4": {"Kayladnls\\DoctrineAdditions\\" : "src/"}

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "6db5fc41e226747802039bb4460cd1cc",
-    "content-hash": "d7da4f8bf70bde770770768e500a9daf",
+    "hash": "33943bbf6265228363353a2bc0a469bd",
+    "content-hash": "7103fe182f8f7bc37fe8642c84647b6f",
     "packages": [],
     "packages-dev": [
         {
@@ -609,36 +609,102 @@
             "time": "2015-08-31 12:59:39"
         },
         {
-            "name": "league/url",
-            "version": "3.3.5",
+            "name": "jeremykendall/php-domain-parser",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/thephpleague/url.git",
-                "reference": "1ae2c3ce29a7c5438339ff6388225844e6479da8"
+                "url": "https://github.com/jeremykendall/php-domain-parser.git",
+                "reference": "896e7e70f02bd4fd77190052799bc61e4d779672"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/url/zipball/1ae2c3ce29a7c5438339ff6388225844e6479da8",
-                "reference": "1ae2c3ce29a7c5438339ff6388225844e6479da8",
+                "url": "https://api.github.com/repos/jeremykendall/php-domain-parser/zipball/896e7e70f02bd4fd77190052799bc61e4d779672",
+                "reference": "896e7e70f02bd4fd77190052799bc61e4d779672",
                 "shasum": ""
             },
             "require": {
+                "ext-curl": "*",
+                "ext-intl": "*",
                 "ext-mbstring": "*",
-                "php": ">=5.3.0",
-                "true/punycode": "^2.0"
+                "php": ">=5.3.0"
             },
             "require-dev": {
+                "jeremykendall/debug-die": "0.0.1.*",
+                "mikey179/vfsstream": "~1.4",
+                "phpunit/phpunit": "~4.4"
+            },
+            "bin": [
+                "bin/parse",
+                "bin/update-psl"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Pdp\\": "src/"
+                },
+                "files": [
+                    "src/pdp-parse-url.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jeremy Kendall",
+                    "homepage": "http://about.me/jeremykendall",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/jeremykendall/php-domain-parser/graphs/contributors"
+                }
+            ],
+            "description": "Public Suffix List based URL parsing implemented in PHP.",
+            "homepage": "https://github.com/jeremykendall/php-domain-parser",
+            "keywords": [
+                "Public Suffix List",
+                "domain parsing",
+                "url parsing"
+            ],
+            "time": "2015-03-30 12:49:45"
+        },
+        {
+            "name": "league/uri",
+            "version": "4.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/uri.git",
+                "reference": "0cbce9fe7d9808690ebda67b110ad96bcae9daee"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/uri/zipball/0cbce9fe7d9808690ebda67b110ad96bcae9daee",
+                "reference": "0cbce9fe7d9808690ebda67b110ad96bcae9daee",
+                "shasum": ""
+            },
+            "require": {
+                "ext-fileinfo": "*",
+                "ext-intl": "*",
+                "ext-mbstring": "*",
+                "jeremykendall/php-domain-parser": "^3.0",
+                "php": ">=5.5.9",
+                "psr/http-message": "^1.0"
+            },
+            "require-dev": {
+                "fabpot/php-cs-fixer": "^1.9",
                 "phpunit/phpunit": "^4.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.3-dev"
+                    "dev-master": "4.1-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "League\\Url\\": "src"
+                    "League\\Uri\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -649,18 +715,24 @@
                 {
                     "name": "Ignace Nyamagana Butera",
                     "email": "nyamsprod@gmail.com",
-                    "homepage": "https://github.com/nyamsprod/",
-                    "role": "Developer"
+                    "homepage": "https://nyamsprod.com"
                 }
             ],
-            "description": "League/url is a lightweight PHP Url manipulating library",
+            "description": "URI manipulation library",
             "homepage": "http://url.thephpleague.com",
             "keywords": [
+                "data",
+                "data-uri",
+                "ftp",
+                "http",
                 "parse_url",
-                "php",
-                "url"
+                "psr-7",
+                "rfc3986",
+                "uri",
+                "url",
+                "ws"
             ],
-            "time": "2015-07-15 08:24:12"
+            "time": "2016-03-24 08:38:29"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -1140,6 +1212,55 @@
             "time": "2015-10-02 06:51:40"
         },
         {
+            "name": "psr/http-message",
+            "version": "1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "85d63699f0dbedb190bbd4b0d2b9dc707ea4c298"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/85d63699f0dbedb190bbd4b0d2b9dc707ea4c298",
+                "reference": "85d63699f0dbedb190bbd4b0d2b9dc707ea4c298",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "time": "2015-05-04 20:22:00"
+        },
+        {
             "name": "sebastian/comparator",
             "version": "1.2.0",
             "source": {
@@ -1611,52 +1732,6 @@
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
             "time": "2015-10-11 09:39:48"
-        },
-        {
-            "name": "true/punycode",
-            "version": "v2.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/true/php-punycode.git",
-                "reference": "b672918d992b84f8016bbe353a42516928393c63"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/true/php-punycode/zipball/b672918d992b84f8016bbe353a42516928393c63",
-                "reference": "b672918d992b84f8016bbe353a42516928393c63",
-                "shasum": ""
-            },
-            "require": {
-                "ext-mbstring": "*",
-                "php": ">=5.3.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.7",
-                "squizlabs/php_codesniffer": "~2.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "TrueBV\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Renan Gonçalves",
-                    "email": "renan.saddam@gmail.com"
-                }
-            ],
-            "description": "A Bootstring encoding of Unicode for Internationalized Domain Names in Applications (IDNA)",
-            "homepage": "https://github.com/true/php-punycode",
-            "keywords": [
-                "idna",
-                "punycode"
-            ],
-            "time": "2015-09-01 14:53:31"
         }
     ],
     "aliases": [],

--- a/src/Type/UrlType.php
+++ b/src/Type/UrlType.php
@@ -4,7 +4,7 @@ namespace Kayladnls\DoctrineAdditions\Type;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\StringType;
-use League\Url\Url;
+use League\Uri;
 
 class UrlType extends StringType
 {
@@ -15,7 +15,7 @@ class UrlType extends StringType
      */
     public function convertToPHPValue($value, AbstractPlatform $platform)
     {
-        return Url::createFromUrl($value);
+        return Uri\Schemes\Http::createFromString($value);
     }
 
     /**

--- a/test/UrlTypeTest.php
+++ b/test/UrlTypeTest.php
@@ -5,7 +5,7 @@ namespace Kayladnls\DoctrineAdditions\Test;
 use Doctrine\ORM\Tools\SchemaTool;
 use Kayladnls\DoctrineAdditions\Test\Entity\LinkedEntity;
 use Kayladnls\DoctrineAdditions\Type\UrlType;
-use League\Url\Url;
+use League\Uri;
 
 class UrlTypeTest extends \PHPUnit_Framework_TestCase
 {
@@ -40,7 +40,7 @@ class UrlTypeTest extends \PHPUnit_Framework_TestCase
 
         $url = new LinkedEntity();
         $url->id = 1;
-        $url->link = Url::createFromUrl("http://github.com/kayladnls?q=is%3Aopen+is%3Apr+author%3Akayladnls");
+        $url->link = Uri\Schemes\Http::createFromString("http://github.com/kayladnls?q=is%3Aopen+is%3Apr+author%3Akayladnls");
         $this->em->persist($url);
         $this->em->flush();
     }
@@ -49,12 +49,9 @@ class UrlTypeTest extends \PHPUnit_Framework_TestCase
     {
         $entity = $this->em->find(LinkedEntity::class, 1);
 
-        $url = Url::createFromUrl("http://github.com/kayladnls?q=is%3Aopen+is%3Apr+author%3Akayladnls");
+        $url = Uri\Schemes\Http::createFromString("http://github.com/kayladnls?q=is%3Aopen+is%3Apr+author%3Akayladnls");
 
-        $this->assertInstanceOf(Url::class, $entity->link);
-        $this->assertEquals($url->getBaseUrl(), $entity->link->getBaseUrl());
-        $this->assertEquals($url->getQuery(), $entity->link->getQuery());
-        $this->assertEquals($url->getScheme(), $entity->link->getScheme());
+        $this->assertInstanceOf(Uri\Schemes\Http::class, $entity->link);
         $this->assertEquals($url, $entity->link);
     }
 
@@ -62,7 +59,7 @@ class UrlTypeTest extends \PHPUnit_Framework_TestCase
     {
         $url = new LinkedEntity();
         $url->id = 2;
-        $url->link = Url::createFromUrl("http://github.com/kayladnls?q=is%3Aopen+is%3Apr+author%3Akayladnls");
+        $url->link = Uri\Schemes\Http::createFromString("http://github.com/kayladnls?q=is%3Aopen+is%3Apr+author%3Akayladnls");
         $this->em->persist($url);
         $this->em->flush();
     }


### PR DESCRIPTION
This PR
- [x] uses `league/uri` instead of `league/url`

Related to https://github.com/refinery29/refinery29/pull/9269.

💁 `league/url` is deprecated, see http://nyamsprod.com/blog/2016/deprecating-a-php-library/.
